### PR TITLE
Compact SQL

### DIFF
--- a/lib/runestone/active_record/base_methods.rb
+++ b/lib/runestone/active_record/base_methods.rb
@@ -40,7 +40,7 @@ module Runestone::ActiveRecord
         conn = Runestone::Model.connection
         model_table = conn.quote_table_name(table_name)
         
-        conn.execute(<<-SQL.gsub("\n", ' ').gsub("\n", ' ').gsub(/\s+/, " ").strip)
+        conn.execute(<<-SQL.gsub("\n", ' ').gsub(/\s+/, " ").strip)
           DELETE FROM runestones
           USING runestones AS t2
           LEFT OUTER JOIN #{model_table} ON
@@ -92,7 +92,7 @@ module Runestone::ActiveRecord
             conn.quote(conn.send(:type_map).lookup('jsonb').serialize(rdata)),
             setting.vectorize(rdata).join(' || ')
           ]
-          conn.execute(<<-SQL.gsub("\n", ' ').gsub("\n", ' ').gsub(/\s+/, " ").strip)
+          conn.execute(<<-SQL.gsub("\n", ' ').gsub(/\s+/, " ").strip)
             INSERT INTO #{Runestone::Model.quoted_table_name} (#{ts_column_names.join(",")})
             VALUES (#{ts_values.join(',')})
           SQL
@@ -112,7 +112,7 @@ module Runestone::ActiveRecord
         settings.each do |setting|
           rdata = setting.extract_attributes(self)
 
-          if conn.execute(<<-SQL.gsub("\n", ' ').gsub("\n", ' ').gsub(/\s+/, " ").strip).cmd_tuples == 0
+          if conn.execute(<<-SQL.gsub("\n", ' ').gsub(/\s+/, " ").strip).cmd_tuples == 0
               UPDATE #{Runestone::Model.quoted_table_name}
               SET
                 data = #{conn.quote(conn.send(:type_map).lookup('jsonb').serialize(rdata))},

--- a/lib/runestone/active_record/base_methods.rb
+++ b/lib/runestone/active_record/base_methods.rb
@@ -40,7 +40,7 @@ module Runestone::ActiveRecord
         conn = Runestone::Model.connection
         model_table = conn.quote_table_name(table_name)
         
-        conn.execute(<<-SQL)
+        conn.execute(<<-SQL.gsub("\n", ' ').gsub("\n", ' ').gsub(/\s+/, " ").strip)
           DELETE FROM runestones
           USING runestones AS t2
           LEFT OUTER JOIN #{model_table} ON
@@ -92,7 +92,7 @@ module Runestone::ActiveRecord
             conn.quote(conn.send(:type_map).lookup('jsonb').serialize(rdata)),
             setting.vectorize(rdata).join(' || ')
           ]
-          conn.execute(<<-SQL)
+          conn.execute(<<-SQL.gsub("\n", ' ').gsub("\n", ' ').gsub(/\s+/, " ").strip)
             INSERT INTO #{Runestone::Model.quoted_table_name} (#{ts_column_names.join(",")})
             VALUES (#{ts_values.join(',')})
           SQL
@@ -112,7 +112,7 @@ module Runestone::ActiveRecord
         settings.each do |setting|
           rdata = setting.extract_attributes(self)
 
-          if conn.execute(<<-SQL).cmd_tuples == 0
+          if conn.execute(<<-SQL.gsub("\n", ' ').gsub("\n", ' ').gsub(/\s+/, " ").strip).cmd_tuples == 0
               UPDATE #{Runestone::Model.quoted_table_name}
               SET
                 data = #{conn.quote(conn.send(:type_map).lookup('jsonb').serialize(rdata))},

--- a/lib/runestone/corpus.rb
+++ b/lib/runestone/corpus.rb
@@ -4,7 +4,7 @@ module Runestone::Corpus
     return if words.size == 0
 
     conn = Runestone::Model.connection
-    conn.execute(<<-SQL)
+    conn.execute(<<-SQL.gsub("\n", ' ').gsub("\n", ' ').gsub(/\s+/, " ").strip)
       INSERT INTO runestone_corpus ( word )
       VALUES (#{words.map { |w| conn.quote(Runestone.normalize(w)) }.join('),(')})
       ON CONFLICT DO NOTHING
@@ -21,7 +21,7 @@ module Runestone::Corpus
     end
     return lut if words.size == 0
     
-    result = conn.execute(<<-SQL)
+    result = conn.execute(<<-SQL.gsub("\n", ' ').gsub("\n", ' ').gsub(/\s+/, " ").strip)
       WITH  tokens (token, token_downcased, typo_tolerance) AS (VALUES (#{words.join('), (')}))
       SELECT token, word, levenshtein(runestone_corpus.word, tokens.token_downcased)
       FROM tokens

--- a/lib/runestone/corpus.rb
+++ b/lib/runestone/corpus.rb
@@ -4,7 +4,7 @@ module Runestone::Corpus
     return if words.size == 0
 
     conn = Runestone::Model.connection
-    conn.execute(<<-SQL.gsub("\n", ' ').gsub("\n", ' ').gsub(/\s+/, " ").strip)
+    conn.execute(<<-SQL.gsub("\n", ' ').gsub(/\s+/, " ").strip)
       INSERT INTO runestone_corpus ( word )
       VALUES (#{words.map { |w| conn.quote(Runestone.normalize(w)) }.join('),(')})
       ON CONFLICT DO NOTHING
@@ -21,7 +21,7 @@ module Runestone::Corpus
     end
     return lut if words.size == 0
     
-    result = conn.execute(<<-SQL.gsub("\n", ' ').gsub("\n", ' ').gsub(/\s+/, " ").strip)
+    result = conn.execute(<<-SQL.gsub("\n", ' ').gsub(/\s+/, " ").strip)
       WITH  tokens (token, token_downcased, typo_tolerance) AS (VALUES (#{words.join('), (')}))
       SELECT token, word, levenshtein(runestone_corpus.word, tokens.token_downcased)
       FROM tokens


### PR DESCRIPTION
Use `.gsub("\n", ' ').gsub(/\s+/, " ").strip` to remove newline and extra whitespace characters.